### PR TITLE
Fix error when trying to create a product archive in Xcode

### DIFF
--- a/ios/Plugin/CapacitorVideoPlayerPlugin.swift
+++ b/ios/Plugin/CapacitorVideoPlayerPlugin.swift
@@ -37,7 +37,7 @@ public class CapacitorVideoPlayerPlugin: CAPPlugin {
 
     override public func load() {
         self.addObserversToNotificationCenter()
-        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiom.pad),
+        if (UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.pad),
            #available(iOS 13.0, *) {
             isPIPModeAvailable = true
         } else if #available(iOS 14.0, *) {


### PR DESCRIPTION
Apparently, regarding [this Apple Dev forum entry](https://developer.apple.com/forums/thread/702200?answerId=707900022#707900022), using `UI_USER_INTERFACE_IDIOM()` causes Xcode 13.3 with Swift 5.6 to fail archiving a build
This should fix issue #82 by implementing the code as stated in forum entry.
