### PR TITLE
Headers support for iOS and Android

### DIFF
--- a/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/CapacitorVideoPlayer.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/CapacitorVideoPlayer.java
@@ -26,6 +26,7 @@ public class CapacitorVideoPlayer {
         String subTitle,
         String language,
         JSObject subTitleOptions,
+        JSObject headers,
         Boolean isTV,
         String playerId,
         Boolean isInternal,
@@ -42,6 +43,7 @@ public class CapacitorVideoPlayer {
         fsFragment.subTitle = subTitle;
         fsFragment.language = language;
         fsFragment.subTitleOptions = subTitleOptions;
+        fsFragment.headers = headers;
         fsFragment.isTV = isTV;
         fsFragment.playerId = playerId;
         fsFragment.isInternal = isInternal;

--- a/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/CapacitorVideoPlayerPlugin.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/CapacitorVideoPlayerPlugin.java
@@ -44,6 +44,7 @@ public class CapacitorVideoPlayerPlugin extends Plugin {
     private FullscreenExoPlayerFragment fsFragment;
     private PickerVideoFragment pkFragment;
     private FilesUtils filesUtils;
+    private JSObject headers;
     private FragmentUtils fragmentUtils;
     private PluginCall call;
     private Float rateList[] = { 0.25f, 0.5f, 0.75f, 1f, 2f, 4f };
@@ -138,10 +139,16 @@ public class CapacitorVideoPlayerPlugin extends Plugin {
                 subTitleOptions = call.getObject("subtitleOptions");
             }
 
+            JSObject headers = new JSObject();
+            if (call.getData().has("headers")) {
+              headers = call.getObject("headers");
+            }
+
             AddObserversToNotificationCenter();
             Log.v(TAG, "display url: " + url);
             Log.v(TAG, "display subtitle: " + subtitle);
             Log.v(TAG, "display language: " + language);
+            Log.v(TAG, "headers: " + headers);
             if (url.equals("internal")) {
                 createPickerVideoFragment(call);
             } else {
@@ -167,6 +174,7 @@ public class CapacitorVideoPlayerPlugin extends Plugin {
                         subTitlePath,
                         language,
                         subTitleOptions,
+                        headers,
                         isTV,
                         playerId,
                         false,
@@ -903,6 +911,7 @@ public class CapacitorVideoPlayerPlugin extends Plugin {
                                 null,
                                 null,
                                 null,
+                                headers,
                                 isTV,
                                 fsPlayerId,
                                 true,
@@ -933,6 +942,7 @@ public class CapacitorVideoPlayerPlugin extends Plugin {
         String subTitle,
         String language,
         JSObject subTitleOptions,
+        JSObject headers,
         Boolean isTV,
         String playerId,
         Boolean isInternal,
@@ -949,6 +959,7 @@ public class CapacitorVideoPlayerPlugin extends Plugin {
                 subTitle,
                 language,
                 subTitleOptions,
+                headers,
                 isTV,
                 playerId,
                 isInternal,

--- a/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/FullscreenExoPlayerFragment.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/FullscreenExoPlayerFragment.java
@@ -63,6 +63,7 @@ import com.google.android.exoplayer2.upstream.HttpDataSource;
 import com.google.android.exoplayer2.util.MimeTypes;
 import com.google.android.exoplayer2.util.Util;
 import com.jeep.plugin.capacitor.capacitorvideoplayer.Notifications.NotificationCenter;
+import org.json.JSONException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -76,6 +77,7 @@ public class FullscreenExoPlayerFragment extends Fragment {
     public String subTitle;
     public String language;
     public JSObject subTitleOptions;
+    public JSObject headers;
     public Boolean isTV;
     public Boolean isInternal;
     public Long videoId;
@@ -597,6 +599,20 @@ public class FullscreenExoPlayerFragment extends Fragment {
             1800000,
             true
         );
+
+        // If headers is not null we pass them to the HttpDataSourceFactory
+        if (headers != null) {
+            // We map the headers(JSObject) to a Map<String, String>
+            Map<String, String> headersMap = new HashMap<String, String>();
+            for(int i = 0; i < headers.names().length(); i++){
+              try {
+                headersMap.put(headers.names().getString(i), headers.get(headers.names().getString(i)).toString());
+              } catch (JSONException e) {
+                e.printStackTrace();
+              }
+            }
+            httpDataSourceFactory.getDefaultRequestProperties().set(headersMap);
+        }
 
         DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(context, httpDataSourceFactory);
 

--- a/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/FullscreenExoPlayerFragment.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/FullscreenExoPlayerFragment.java
@@ -600,8 +600,8 @@ public class FullscreenExoPlayerFragment extends Fragment {
             true
         );
 
-        // If headers is not null we pass them to the HttpDataSourceFactory
-        if (headers != null) {
+        // If headers is not null and has data we pass them to the HttpDataSourceFactory
+        if (headers != null && headers.length() > 0) {
             // We map the headers(JSObject) to a Map<String, String>
             Map<String, String> headersMap = new HashMap<String, String>();
             for(int i = 0; i < headers.names().length(); i++){

--- a/dist/esm/definitions.d.ts
+++ b/dist/esm/definitions.d.ts
@@ -145,6 +145,11 @@ export interface capVideoPlayerOptions {
      * Player height (mode "embedded" only)
      */
     height?: number;
+    /**
+     * Headers for the request (iOS, Android)
+     * by Manuel García Marín (https://github.com/PhantomPainX)
+     */
+    headers?: { [key: string]: string };
 }
 export interface capVideoPlayerIdOptions {
     /**

--- a/docs/API.md
+++ b/docs/API.md
@@ -398,6 +398,7 @@ Stop all players playing
 | **`componentTag`**    | <code>string</code>                                         | Component Tag or DOM Element Tag (React app)                                                  |
 | **`width`**           | <code>number</code>                                         | Player Width (mode "embedded" only)                                                           |
 | **`height`**          | <code>number</code>                                         | Player height (mode "embedded" only)                                                          |
+| **`headers`**         | <code>Any (string: string)</code>                          | Headers to be pass to video player (iOS, Android only)                                         |
 
 
 #### SubTitleOptions

--- a/ios/Plugin/CapacitorVideoPlayer.swift
+++ b/ios/Plugin/CapacitorVideoPlayer.swift
@@ -19,6 +19,7 @@ enum CapacitorVideoPlayerError: Error {
                                              pipEnabled: Bool,
                                              subTitleUrl: URL?,
                                              language: String?,
+                                             headers: [String: String]?,
                                              options: [String: Any]?
 
     ) -> FullScreenVideoPlayerView {
@@ -27,7 +28,7 @@ enum CapacitorVideoPlayerError: Error {
             url: videoUrl, rate: rate, playerId: playerId,
             exitOnEnd: exitOnEnd, loopOnEnd: loopOnEnd,
             pipEnabled: pipEnabled, stUrl: subTitleUrl,
-            stLanguage: language, stOptions: options)
+            stLanguage: language, stHeaders: headers, stOptions: options)
         return videoPlayerFullScreenView
     }
     // swiftlint:enable function_parameter_count

--- a/ios/Plugin/CapacitorVideoPlayerPlugin.swift
+++ b/ios/Plugin/CapacitorVideoPlayerPlugin.swift
@@ -22,6 +22,7 @@ public class CapacitorVideoPlayerPlugin: CAPPlugin {
     var loopOnEnd: Bool = false
     var pipEnabled: Bool = true
     var backModeEnabled: Bool = true
+    var headers: [String: String]?
     var fsPlayerId: String = "fullscreen"
     var videoRate: Float = 1.0
     var playObserver: Any?
@@ -99,6 +100,10 @@ public class CapacitorVideoPlayerPlugin: CAPPlugin {
                 loopOnEnd = sloopOnEnd
             }
         }
+        var headers: [String: String]?
+        if let sheaders = call.options["headers"] as? [String: String] {
+            headers = sheaders
+        }
         var pipEnabled: Bool = true
         if let spipEnabled = call.options["pipEnabled"] as? Bool {
             pipEnabled = spipEnabled
@@ -113,6 +118,7 @@ public class CapacitorVideoPlayerPlugin: CAPPlugin {
         self.exitOnEnd = exitOnEnd
         self.loopOnEnd = loopOnEnd
         self.pipEnabled = pipEnabled
+        self.headers = headers
         if !self.pipEnabled {isPIPModeAvailable = false}
         self.backModeEnabled = bkModeEnabled
         if mode == "fullscreen" {
@@ -190,7 +196,8 @@ public class CapacitorVideoPlayerPlugin: CAPPlugin {
                     backModeEnabled: backModeEnabled,
                     subTitleUrl: subTitle,
                     subTitleLanguage: subTitleLanguage,
-                    subTitleOptions: subTitleOptions)
+                    subTitleOptions: subTitleOptions,
+                    headers: headers)
 
             }
         } else {

--- a/ios/Plugin/Extensions/CapacitorVideoPlayerPlugin.Fullscreen.swift
+++ b/ios/Plugin/Extensions/CapacitorVideoPlayerPlugin.Fullscreen.swift
@@ -20,7 +20,7 @@ extension CapacitorVideoPlayerPlugin {
         call: CAPPluginCall, videoUrl: URL, rate: Float,
         exitOnEnd: Bool, loopOnEnd: Bool, pipEnabled: Bool,
         backModeEnabled: Bool, subTitleUrl: URL?,
-        subTitleLanguage: String?, subTitleOptions: [String: Any]?) {
+        subTitleLanguage: String?, subTitleOptions: [String: Any]?, headers: [String: String]?) {
         DispatchQueue.main.async { [weak self] in
             let playerId: String = self?.fsPlayerId ?? "fullscreen"
             if let fullscreenView = self?.implementation
@@ -29,7 +29,7 @@ extension CapacitorVideoPlayerPlugin {
                     rate: rate, exitOnEnd: exitOnEnd, loopOnEnd: loopOnEnd,
                     pipEnabled: pipEnabled,
                     subTitleUrl: subTitleUrl,
-                    language: subTitleLanguage, options: subTitleOptions) {
+                    language: subTitleLanguage, headers: headers, options: subTitleOptions) {
                 self?.videoPlayerFullScreenView = fullscreenView
                 if backModeEnabled {
                     self?.bgPlayer = self?.videoPlayerFullScreenView?

--- a/ios/Plugin/Extensions/CapacitorVideoPlayerPlugin.Observers.swift
+++ b/ios/Plugin/Extensions/CapacitorVideoPlayerPlugin.Observers.swift
@@ -164,7 +164,7 @@ extension CapacitorVideoPlayerPlugin {
             call: call, videoUrl: videoUrl,
             rate: videoRate, exitOnEnd: exitOnEnd, loopOnEnd: loopOnEnd,
             pipEnabled: pipEnabled, backModeEnabled: backModeEnabled,
-            subTitleUrl: nil, subTitleLanguage: nil, subTitleOptions: nil)
+            subTitleUrl: nil, subTitleLanguage: nil, subTitleOptions: nil, headers: nil)
         return
     }
 

--- a/ios/Plugin/VideoPlayer/FullScreenVideoPlayerView.swift
+++ b/ios/Plugin/VideoPlayer/FullScreenVideoPlayerView.swift
@@ -53,7 +53,13 @@ open class FullScreenVideoPlayerView: UIView {
         self._videoRate = rate
         self._stHeaders = stHeaders
         self.videoPlayer = AVPlayerViewController()
-        self.videoAsset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": stHeaders])
+        
+        if stHeaders != nil {
+            self.videoAsset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": stHeaders])
+        } else {
+            self.videoAsset = AVURLAsset(url: url)
+        }
+
         self.isPlaying = false
         super.init(frame: .zero)
         self.initialize()

--- a/ios/Plugin/VideoPlayer/FullScreenVideoPlayerView.swift
+++ b/ios/Plugin/VideoPlayer/FullScreenVideoPlayerView.swift
@@ -24,6 +24,7 @@ open class FullScreenVideoPlayerView: UIView {
     private var _firstReadyToPlay: Bool = true
     private var _stUrl: URL?
     private var _stLanguage: String?
+    private var _stHeaders: [String: String]?
     private var _stOptions: [String: Any]?
     private var _videoRate: Float
 
@@ -39,7 +40,7 @@ open class FullScreenVideoPlayerView: UIView {
 
     init(url: URL, rate: Float, playerId: String, exitOnEnd: Bool,
          loopOnEnd: Bool, pipEnabled: Bool, stUrl: URL?,
-         stLanguage: String?, stOptions: [String: Any]?) {
+         stLanguage: String?, stHeaders: [String: String]?, stOptions: [String: Any]?) {
         //self._videoPath = videoPath
         self._url = url
         self._stUrl = stUrl
@@ -50,8 +51,9 @@ open class FullScreenVideoPlayerView: UIView {
         self._pipEnabled = pipEnabled
         self._videoId = playerId
         self._videoRate = rate
+        self._stHeaders = stHeaders
         self.videoPlayer = AVPlayerViewController()
-        self.videoAsset = AVURLAsset(url: url)
+        self.videoAsset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": stHeaders])
         self.isPlaying = false
         super.init(frame: .zero)
         self.initialize()

--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,7 @@ No configuration required for this plugin
 | initPlayer (url internal)          | ✅      | ✅  | ❌       | ❌  |
 | initPlayer (url application/files) | ✅      | ✅  | ❌       | ❌  |
 | initPlayer (subtitles)             | ✅      | ✅  | ❌       | ❌  |
+| initPlayer (headers)               | ✅      | ✅  | ❌       | ❌  |
 | isPlaying                          | ✅      | ✅  | ✅       | ✅  |
 | play                               | ✅      | ✅  | ✅       | ✅  |
 | pause                              | ✅      | ✅  | ✅       | ✅  |
@@ -233,6 +234,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/mamane10"><img src="https://avatars.githubusercontent.com/u/46500089?v=4" width="100px;" alt=""/><br /><sub><b>Mamane10</b></sub></a><br /><a href="https://github.com/jepiqueau/capacitor-video-player/commits?author=mamane10" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/KANekT"><img src="https://avatars.githubusercontent.com/u/580273?v=4" width="100px;" alt=""/><br /><sub><b>Пронин Андрей KANekT</b></sub></a><br /><a href="https://github.com/jepiqueau/capacitor-video-player/commits?author=KANekT" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/mueslirieger"><img src="https://avatars.githubusercontent.com/u/20973893?v=4" width="100px;" alt=""/><br /><sub><b>Michael Rieger</b></sub></a><br /><a href="https://github.com/jepiqueau/capacitor-video-player/commits?author=mueslirieger" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/PhantomPainX"><img src="https://avatars.githubusercontent.com/u/47803967?v=4" width="100px;" alt=""/><br /><sub><b>Manuel García Marín</b></sub></a><br /><a href="https://github.com/jepiqueau/capacitor-video-player/commits?author=PhantomPainX" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -148,6 +148,11 @@ export interface capVideoPlayerOptions {
    * Player height (mode "embedded" only)
    */
   height?: number;
+  /**
+   * Headers for the request (iOS, Android)
+   * by Manuel García Marín (https://github.com/PhantomPainX)
+   */
+  headers?: { [key: string]: string };
 }
 export interface capVideoPlayerIdOptions {
   /**


### PR DESCRIPTION
### What changed?
Headers support was added for Android and iOS. With this PR, headers can be used in as a dictionary of strings in _capVideoPlayerOptions_

### Why headers should be needed?
Sometimes when you have to access to a remote video url, some authorizations, referer or other headers needs to be passed in the request, otherwhise the video server end would deny your petition.

### Example (IONIC/Capacitor)
```
nativePlayer(video: any) {

    CapacitorVideoPlayer.initPlayer({
      mode: 'fullscreen',
      url: video.file,
      playerId: 'player1',
      headers: {
        Referer: video.referer
      }
    }).then(() => {
      console.log('Player initialized');
      CapacitorVideoPlayer.play({playerId: 'player1'}).then(() => {
        console.log('Player playing');
      });
    });
  }
```

