### PR TITLE
Android: Check pipEnabled in backPressed function

### DIFF
--- a/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/FullscreenExoPlayerFragment.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capacitorvideoplayer/FullscreenExoPlayerFragment.java
@@ -398,7 +398,8 @@ public class FullscreenExoPlayerFragment extends Fragment {
             !isInPictureInPictureMode &&
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
             packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) &&
-            isPIPModeeEnabled
+            isPIPModeeEnabled &&
+            pipEnabled
         ) {
             pictureInPictureMode();
         } else {


### PR DESCRIPTION
Before when the backPressed functions was called and pipEnabled was false, pictureInPictureMode would still be called. This change checks if pipEnabled is true before calling pictureInPictureMode.