### PR TITLE
fix: Invalid regular expression

### DIFF
--- a/src/web-utils/videoplayer.ts
+++ b/src/web-utils/videoplayer.ts
@@ -316,7 +316,7 @@ export class VideoPlayer {
       // e.g. https://youtube.com/?v=3982748927&filetype=mkv
       const hasNotSupportedExtensionInUrl = sUrl.match(
         new RegExp(
-          `(${possibleQueryParameterExtensions.join('|')})\=+(.*)&?(?=&|$))`,
+          `(${possibleQueryParameterExtensions.join('|')})\=+(.*)&?(?=&|$)`,
           'i',
         ),
       );


### PR DESCRIPTION
Fix regex expression within the `hasNotSupportedExtensionInUrl` check (additional closing parenthesis at end)

Before
```ts
/(file|extension|filetype|type|ext)=+(.*)&?(?=&|$))/i:
```

After
```ts
/(file|extension|filetype|type|ext)=+(.*)&?(?=&|$)/i:
```

Example runtime error
![image](https://github.com/user-attachments/assets/862a5cd1-c0fa-444e-9d80-cf4b58f6cbc0)


I'm guessing this check doesn't get reached very often, in my local project I'm using Object URLs so the src ends up something like `blob:http://localhost:4200/f8a6e27f-00b4-4cf7-854e-a9f6d0296348`, which doesn't have any extension (is mp4 though so previously would still play as expected as default fallback)
